### PR TITLE
Complete the start and reset scripts

### DIFF
--- a/src/reset.sh
+++ b/src/reset.sh
@@ -17,6 +17,16 @@ for node_dir in node*/; do
         fi
     done
 
+    # Iterate through the list and remove each file
+    for file in "${files[@]}"; do
+        if [ -f "$node_dir$file" ]; then
+            rm "$node_dir$file"
+            echo "Removed $file in $node_dir"
+        else
+            echo "$file does not exist in $node_dir"
+        fi
+    done
+
     # Reset the genesis_timestamp in genesis.json to 0
     if [ -f "$node_dir/genesis.json" ]; then
         jq '.genesis_timestamp = 0' "$node_dir/genesis.json" > tmp.$$.json && mv tmp.$$.json "$node_dir/genesis.json"

--- a/src/start.sh
+++ b/src/start.sh
@@ -7,6 +7,13 @@ files=("block.py" "merkle_tree.py" "peer_communication.py" "requirements.txt" "t
 current_time=$(date +%s)
 genesis_timestamp=$((current_time + 60))
 
+# Copy files from src/tinychain to each node* directory
+for node_dir in node*; do
+    for file in "${files[@]}"; do
+        cp "src/tinychain/$file" "$node_dir/"
+    done
+done
+
 for node in node*/genesis.json; do
     jq --argjson timestamp "$genesis_timestamp" '.genesis_timestamp = $timestamp' "$node" > tmp.$$.json && mv tmp.$$.json "$node"
 done


### PR DESCRIPTION
Add functionality to start and reset scripts to manage node directories and files.

* **start.sh**
  - Add a loop to copy files from `src/tinychain` to each `node*` directory.
  - Use `cp` command to copy each file in the `files` array to the corresponding `node*` directory.

* **reset.sh**
  - Add a loop to delete each file in the `files` array from each `node*` directory.
  - Check if the file exists before attempting to delete it and provide feedback.

